### PR TITLE
Fix tag and runner in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Build and upload artifacts
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   # Validate that the git tag matches the version string in Cargo.toml.
@@ -44,7 +44,7 @@ jobs:
           # Windows hosts
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-    runs-on: ${{ matrix.os }}.
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4


### PR DESCRIPTION
Tags for this repository use the `vX.Y.Z` format, rather than `X.Y.Z`.

Additionally, there was a typo in the `runs-on` label, which meant that the job was never getting picked up.